### PR TITLE
Add qtdeclarative5-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM debian:10-slim as compile-plugin
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV TERM="xterm"
 
-RUN apt-get update && apt-get install -y git qt5-default libqt5websockets5-dev libqt5serialport5-dev sqlite3 libcap2-bin lsof curl libsqlite3-dev libssl-dev g++ make gnupg2
+RUN apt-get update && apt-get install -y git qt5-default libqt5websockets5-dev libqt5serialport5-dev qtdeclarative5-dev sqlite3 libcap2-bin lsof curl libsqlite3-dev libssl-dev g++ make gnupg2
 
 RUN curl -L http://phoscon.de/apt/deconz.pub.key | apt-key add -
 RUN sh -c "echo 'deb [arch=amd64] http://phoscon.de/apt/deconz \


### PR DESCRIPTION
Add `qtdeclarative5-dev` as required on current builds of deconz.

Without it, the following error is thrown:
```
Info: creating stash file /deconz-rest-plugin/.qmake.stash
Project ERROR: Unknown module(s) in QT: qml
The command '/bin/sh -c git clone $PLUGIN_REPOSITORY && cd deconz-rest-plugin && git checkout $PLUGIN_GIT_COMMIT && qmake && make -j2' returned a non-zero code: 3
```